### PR TITLE
Fix: 에러 응답 처리 수정 - client응답 인터셉터 주석 수정,loginApi error응답수정, login error message 수정

### DIFF
--- a/apps/user/src/entities/session/api/loginApi.ts
+++ b/apps/user/src/entities/session/api/loginApi.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { client, ResponseWith, setCookie } from '../../../shared';
 import { AuthBody, Token } from '../types';
 
@@ -15,10 +16,13 @@ export const loginApi = async (credentials: AuthBody) => {
       setCookie('accessToken', accessToken);
       setCookie('refreshToken', refreshToken);
     }
-
-    return response.data;
+    return Promise.resolve(response.data);
   } catch (error) {
-    console.error('Login API error:', error);
-    throw error;
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        return Promise.resolve(error.response.data); // 오류를 포함한 응답 반환
+      }
+    }
+    return Promise.reject(error); // 네트워크 오류 등 처리할 수 없는 오류는 reject
   }
 };

--- a/apps/user/src/features/session/model/validation.ts
+++ b/apps/user/src/features/session/model/validation.ts
@@ -53,7 +53,7 @@ export const validateSiginupConfirmPassword = (
 export const validateLogIn = async (credentials: AuthBody) => {
   const response = await loginApi(credentials);
   if (response.code === 200) return null;
-  if (response.code === 400 && response.msg.includes('Wrong password'))
+  if (response.code === 400 && response.msg.includes('password'))
     return '비밀번호가 올바르지 않습니다.';
   if (response.code === 400 && response.msg.includes('email'))
     return '이메일 형식을 확인해주세요.';

--- a/apps/user/src/shared/model/client.ts
+++ b/apps/user/src/shared/model/client.ts
@@ -76,13 +76,9 @@ client.interceptors.response.use(
       _retry?: boolean;
     };
 
-    // 로그인/회원가입 에러 메시지를 위한 분기 처리
-    // if (
-    //   error.response?.status === 400 ||
-    //   (error.response?.status === 404 &&
-    //     ((error.config && error.config.url === '/member/signin') ||
-    //       (error.config && error.config.url === '/member/signup')))
-    // ) {
+    //에러 메시지를 return 하기 위한 분기 처리
+    // if (axios.isAxiosError(error) && error.response) {
+    //   // 모든 에러 코드의 response를 반환
     //   return Promise.resolve(error.response);
     // }
 


### PR DESCRIPTION
Related to:#5

- 로그인 에러메세지가 생기지 않는 오류 수정
- 오류를 포함한 response를 받기 위해  `return Promise.resolve(error.response);` 리턴문을
axios응답 인터셉트 안이 아닌, 에러 메세지가 필요한 loginApi요청 로직 안에 추가하였습니다.

```
  // 로그인/회원가입 에러 메시지를 위한 분기 처리
    if (
      error.response?.status === 400 ||
      (error.response?.status === 404 &&
        ((error.config && error.config.url === '/member/signin') ||
          (error.config && error.config.url === '/member/signup')))
    ) {
      return Promise.resolve(error.response);
    }
```

기존 코드인, 특정 url의 response에 따라 에러메세지를 처리하려고 했던
위 상태에서는 분기처리한 signin, sifnou 이외의 url의 axios 에러를 못받는 이슈가 있었습니다.

client.ts에서 위 부분을 삭제하고,
login.api에서 여러 에러 메세지를 클라이언트 단에서 사용할 수 있도록 아래 코드로 수정하였습니다.

```
  try {
    const response = await axios.post('/api/login', credentials);
    return Promise.resolve(response.data);
  } catch (error) {
    if (error.response) {
      return Promise.resolve(error.response.data); // 오류를 포함한 응답 반환
    }
    return Promise.reject(error); // 네트워크 오류 등 처리할 수 없는 오류는 reject
  }
```

응답 인터셉트 안에 위에서 삭제한 코드 자리에 아래의 코드를 추가하면,
loginAPI와 같이 console.error나 throw error가 아닌, 
클라이언트 단에서 오류를 포함한 응답을 반환받아 에러 상태에 따른 분기처리를 해줄 수 도 있습니다.

```
//에러 메시지를 return 하기 위한 분기 처리
    if (axios.isAxiosError(error) && error.response) {
       // 모든 에러 코드의 response를 반환
       return Promise.resolve(error.response);
    }
```

